### PR TITLE
Rejection Exceptions

### DIFF
--- a/src/GenericApi.php
+++ b/src/GenericApi.php
@@ -158,6 +158,9 @@ class GenericApi implements ApiInterface
 
         return (new EachPromise($promises, [
             'concurrency' => $concurrency,
+            'rejected' => function (\Exception $e) {
+                throw $e;
+            },
             'fulfilled' => function ($response) use (&$result) {
                 $result[] = $response;
             },


### PR DESCRIPTION
When fetching async, throw exception on rejected promises.